### PR TITLE
Fix error Unclosed '[' on line 27

### DIFF
--- a/database/seeds/DemoSeeder.php
+++ b/database/seeds/DemoSeeder.php
@@ -27,7 +27,7 @@ class DemoSeeder extends Seeder
             Login::factory()->count(5)->create([
                 'user_id' => $user->id,
                 'tenant_id' => $user->tenant_id,
-            );
+            ]);
         }
         User::factory()->count(1)->create([
             'tenant_id' => null,


### PR DESCRIPTION
Fix error Unclosed '[' on line 27 does not match ')' at database/seeds/DemoSeeder.php:30 when running migrations and seeds.